### PR TITLE
Updating Links to PhoneGap Build community

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,13 @@
 PhoneGap Build 
 =====
 
-**Please start a discussion in the [PhoneGap Build Support Forum](http://community.phonegap.com) prior to opening an issue here**.
+**Please start a discussion in the [PhoneGap Build Support Forum](https://forums.adobe.com/community/phonegap/build) prior to opening an issue here**.
 
 This repository is a bug tracker for PhoneGap Build. Issues here should be limited to the PhoneGap Build web service (the site, the REST API, or compilation problems). If your issue is with usage of the PhoneGap framework, you should take it to one of the channels below.
 
 Prior to creating an issue please:
-- Search both this repo and the [PhoneGap Build Support Forum](http://community.phonegap.com) for an existing issue that might solve your problem.
-- Start a discussion at [PhoneGap Build Support Forum](http://community.phonegap.com)
+- Search both this repo and the [PhoneGap Build Support Forum](https://forums.adobe.com/community/phonegap/build) for an existing issue that might solve your problem.
+- Start a discussion at [PhoneGap Build Support Forum](https://forums.adobe.com/community/phonegap/build)
 
 If your issue is with usage of the PhoneGap framework, please go to:
 - [The PhoneGap Google Group](http://groups.google.com/group/phonegap)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 PhoneGap Build 
 =====
 
-**Please start a discussion in the [PhoneGap Build Support Forum](http://community.phonegap.com) prior to opening an issue here**.
+**Please start a discussion in the [PhoneGap Build Support Forum](https://forums.adobe.com/community/phonegap/build) prior to opening an issue here**.
 
 This repository is a bug tracker for PhoneGap Build. Issues here should be limited to the PhoneGap Build web service (the site, the REST API, or compilation problems). If your issue is with usage of the PhoneGap framework, you should take it to one of the channels below.
 
 Prior to creating an issue please:
-- Search both this repo and the [PhoneGap Build Support Forum](http://community.phonegap.com) for an existing issue that might solve your problem.
-- Start a discussion at [PhoneGap Build Support Forum](http://community.phonegap.com)
+- Search both this repo and the [PhoneGap Build Support Forum](https://forums.adobe.com/community/phonegap/build) for an existing issue that might solve your problem.
+- Start a discussion at [PhoneGap Build Support Forum](https://forums.adobe.com/community/phonegap/build)
 
 If your issue is with usage of the PhoneGap framework, please go to:
 - [The PhoneGap Google Group](http://groups.google.com/group/phonegap)


### PR DESCRIPTION
It seems that the links were outdated, and were now after the redirect going to the phonegap communities instead of the phonegap build communities.